### PR TITLE
Update navigation header links

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,4 +36,6 @@ sass:
 # Pages to include in header navigation
 header_pages:
   - index.md
-  - guide.md
+  - heywim/index.md
+  - keyper/index.md
+  - noodlebar/index.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Poort8 Docs"
+title: "Docs"
 nav_order: 1
 has_children: true
 layout: default


### PR DESCRIPTION
## Summary
- update `index.md` to use 'Docs' title
- add product links to `header_pages` in `_config.yml`

## Testing
- `bundle exec jekyll build --source docs`
- `bundle exec htmlproofer ./_site --disable-external`
