### PR TITLE
Update sidebar hierarchy

### DIFF
--- a/docs/heywim/faq.md
+++ b/docs/heywim/faq.md
@@ -2,9 +2,8 @@
 title: "FAQ"
 nav_order: 20
 parent: "HeyWim"
+grand_parent: "Implementations"
 layout: default
----title: "FAQ"
-nav_order: 10
 ---
 
 ## Frequently Asked Questions
@@ -24,3 +23,4 @@ A: The API supports validation, event retrieval, and milestone extraction based 
 ### Q: Where can I find the HeyWim API documentation?
 
 A: You can find the HeyWim API documentation [here](https://poort8.github.io/Poort8.HeyWim.Swagger/).
+

--- a/docs/heywim/index.md
+++ b/docs/heywim/index.md
@@ -1,6 +1,7 @@
 ---
 title: "HeyWim"
-nav_order: 10
+nav_order: 1
+parent: "Implementations"
 has_children: true
 layout: default
 ---

--- a/docs/heywim/quick-start.md
+++ b/docs/heywim/quick-start.md
@@ -2,6 +2,7 @@
 title: "Quick Start"
 nav_order: 10
 parent: "HeyWim"
+grand_parent: "Implementations"
 layout: default
 ---
 

--- a/docs/heywim/sources.md
+++ b/docs/heywim/sources.md
@@ -2,6 +2,7 @@
 title: "Data Sources"
 parent: "HeyWim"
 nav_order: 15
+grand_parent: "Implementations"
 layout: default
 ---
 

--- a/docs/keyper/faq.md
+++ b/docs/keyper/faq.md
@@ -3,8 +3,6 @@ title: "FAQ"
 nav_order: 20
 parent: "Keyper"
 layout: default
----title: "FAQ"
-nav_order: 10
 ---
 
 ## Frequently Asked Questions
@@ -24,3 +22,4 @@ A: The API supports signed, auditable approvals and optional orchestration steps
 ### Q: Where can I find the Keyper API documentation?
 
 A: You can find the Keyper API documentation [here](https://keyper-preview.poort8.nl/scalar/).
+

--- a/docs/keyper/implementations/dvu/context.md
+++ b/docs/keyper/implementations/dvu/context.md
@@ -1,8 +1,8 @@
 ---
-title: "DVU Context"
-nav_order: 20
-parent: "Implementations"
-grand_parent: "Keyper"
+title: "Context"
+nav_order: 10
+parent: "DVU"
+grand_parent: "Implementations"
 layout: default
 ---
 

--- a/docs/keyper/implementations/dvu/gebouwen-in-bulk.md
+++ b/docs/keyper/implementations/dvu/gebouwen-in-bulk.md
@@ -1,6 +1,8 @@
 ---
-title: "DVU Context"
+title: "Multiple Buildings"
 nav_order: 20
+parent: "DVU"
+grand_parent: "Implementations"
 layout: default
 ---
 

--- a/docs/keyper/implementations/dvu/index.md
+++ b/docs/keyper/implementations/dvu/index.md
@@ -1,8 +1,8 @@
 ---
-title: "DVU Context"
-nav_order: 20
+title: "DVU"
+nav_order: 2
 parent: "Implementations"
-grand_parent: "Keyper"
+has_children: true
 layout: default
 ---
 

--- a/docs/keyper/implementations/gir/index.md
+++ b/docs/keyper/implementations/gir/index.md
@@ -1,8 +1,7 @@
 ---
-title: "GIR Context"
-nav_order: 40
+title: "GIR"
+nav_order: 3
 parent: "Implementations"
-grand_parent: "Keyper"
 layout: default
 ---
 

--- a/docs/keyper/implementations/index.md
+++ b/docs/keyper/implementations/index.md
@@ -1,7 +1,6 @@
 ---
 title: "Implementations"
 nav_order: 5
-parent: "Keyper"
 has_children: true
 layout: default
 ---

--- a/docs/keyper/index.md
+++ b/docs/keyper/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Keyper"
-nav_order: 12
+nav_order: 3
 has_children: true
 layout: default
 ---

--- a/docs/noodlebar/faq.md
+++ b/docs/noodlebar/faq.md
@@ -1,10 +1,9 @@
 ---
 title: "FAQ"
 nav_order: 20
-parent: "Noodlebar"
+parent: "NoodleBar"
 layout: default
----title: "FAQ"
-nav_order: 10
 ---
 
 ## Work in progress
+

--- a/docs/noodlebar/index.md
+++ b/docs/noodlebar/index.md
@@ -1,6 +1,6 @@
 ---
 title: "NoodleBar"
-nav_order: 11
+nav_order: 4
 has_children: true
 layout: default
 ---


### PR DESCRIPTION
## Summary
- reorder top-level pages in sidebar
- move HeyWim under new `Implementations` section
- surface DVU and GIR under `Implementations`
- clean duplicate front‑matter in various docs

## Testing
- `bundle exec rspec`