### PR TITLE
Add subpages sections to HeyWim and DVU pages

### DIFF
--- a/docs/heywim/index.md
+++ b/docs/heywim/index.md
@@ -5,3 +5,8 @@ parent: "Implementations"
 has_children: true
 layout: default
 ---
+
+## Subpages
+- [Quick Start](quick-start.html)
+- [Data Sources](sources.html)
+- [FAQ](faq.html)

--- a/docs/keyper/implementations/dvu/index.md
+++ b/docs/keyper/implementations/dvu/index.md
@@ -6,6 +6,10 @@ has_children: true
 layout: default
 ---
 
+## Subpages
+- [Add single building](context.html)
+- [Add multiple buildings](gebouwen-in-bulk.html)
+
 # DVU Implementation Context
 
 #work-in-progress


### PR DESCRIPTION
## Summary
- list subpages at the top of HeyWim docs page
- list subpages at the top of DVU docs page

## Testing
- `bundle exec rspec`
- `pre-commit run --files docs/heywim/index.md docs/keyper/implementations/dvu/index.md` *(fails: command not found)*