### PR TITLE
Fix docs links and placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository follows the GitHub Pages with Jekyll structure using the `/docs`
 ├── Gemfile               # Ruby dependencies
 └── README.md            # This file
 
+```
 ## Setting up the Devcontainer
 
 To set up the devcontainer for building and testing this repository in GitHub Codespaces, follow these steps:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -81,4 +81,4 @@ Keyper Approve supports several enhancements to the introductory approval flow:
 | Provider              | –    | Registry checks             | Provider connector |   |
 | Consumer              |Requests or view status  | –           | Consumer connector |   |
 
-> **Next steps:** Deep‑dive into [Keyper Approve API](#) or [NoodleBar API](#) when you’re ready to implement.
+> **Next steps:** Deep‑dive into [Keyper Approve API](https://keyper-preview.poort8.nl/scalar/) or [NoodleBar API](https://noodlebar.poort8.nl/scalar/) when you’re ready to implement.

--- a/docs/heywim/faq.md
+++ b/docs/heywim/faq.md
@@ -2,7 +2,6 @@
 title: "FAQ"
 nav_order: 20
 parent: "HeyWim"
-grand_parent: "Implementations"
 layout: default
 ---
 

--- a/docs/heywim/index.md
+++ b/docs/heywim/index.md
@@ -1,7 +1,6 @@
 ---
 title: "HeyWim"
 nav_order: 1
-parent: "Implementations"
 has_children: true
 layout: default
 ---

--- a/docs/heywim/quick-start.md
+++ b/docs/heywim/quick-start.md
@@ -2,8 +2,13 @@
 title: "Quick Start"
 nav_order: 10
 parent: "HeyWim"
-grand_parent: "Implementations"
 layout: default
 ---
 
-## Work in progress
+Follow these steps to start experimenting with HeyWim:
+
+1. **Register for access** – Contact Poort8 to obtain credentials for the sandbox environment.
+2. **Retrieve a tracking token** – Use your credentials to request a bearer token from the HeyWim token server.
+3. **Call the events endpoint** – Query `/events` with a booking or container reference to fetch live milestones.
+4. **Handle webhooks** – Optionally register a callback URL to receive real‑time event updates.
+5. **Explore the API documentation** – Visit the [HeyWim Swagger site](https://poort8.github.io/Poort8.HeyWim.Swagger/) for all available operations.

--- a/docs/heywim/sources.md
+++ b/docs/heywim/sources.md
@@ -2,7 +2,6 @@
 title: "Data Sources"
 parent: "HeyWim"
 nav_order: 15
-grand_parent: "Implementations"
 layout: default
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ NoodleBar gives organizations complete control over how their data is shared.
 You define who can access your data and under what conditions — and you can change both at any moment. Data is shared directly from the source, avoiding centralized data silos. NoodleBar includes composable modules like:
 
 - Role-based access control (RBAC) for M2M access
-- Authorizarion register
+- Authorization register
 - Organization register
 - Token server
 - OpenAPI-powered service catalog

--- a/docs/keyper/implementations/dvu/context.md
+++ b/docs/keyper/implementations/dvu/context.md
@@ -62,7 +62,7 @@ Content-Type: application/json
   },
   "approver": {
     "email": "<EMAIL_ENERGIECONTRACTANT>",
-    "organization": "<ORANISATIE_ENERGIECONTRACTANT>",
+    "organization": "<ORGANISATIE_ENERGIECONTRACTANT>",
     "organizationId": "<EORI_ENERGIECONTRACTANT>"
   },
   "dataspace": {

--- a/docs/noodlebar/faq.md
+++ b/docs/noodlebar/faq.md
@@ -5,5 +5,13 @@ parent: "NoodleBar"
 layout: default
 ---
 
-## Work in progress
+## Frequently Asked Questions
 
+### Q: What is NoodleBar?
+A: NoodleBar is Poort8's modular dataspace infrastructure that combines registries, token services and enforcement endpoints.
+
+### Q: Can I use NoodleBar with my existing API gateway?
+A: Yes. NoodleBar's enforcement endpoints can be invoked from any gateway that supports HTTP calls.
+
+### Q: Where do I find the API specification?
+A: The full OpenAPI specification is hosted at [https://noodlebar.poort8.nl/scalar/](https://noodlebar.poort8.nl/scalar/).

--- a/docs/noodlebar/index.md
+++ b/docs/noodlebar/index.md
@@ -21,4 +21,4 @@ In very many cases, a typical user process in a dataspace use case does not star
 
 In  dataspace standards only step 3 is standardized. E.g. for DSGO and iSHARE, the endpoint delegation is used for this. NoodleBar provides various enforce endpoints out of the box, see Authorization.
 
-The process for Step 1, requesting access, and Step 2, registering conditions, is often a domain of even usecase specific process, that needs to tie in tightly to existing access management or collaboration processes. In NoodleBar, dataspace managers have the discretion to give access to trusted control plane apps for facilitating these processes, such as [Keyper Approve].
+The process for Step 1, requesting access, and Step 2, registering conditions, is often a domain of even usecase specific process, that needs to tie in tightly to existing access management or collaboration processes. In NoodleBar, dataspace managers have the discretion to give access to trusted control plane apps for facilitating these processes, such as [Keyper Approve](../keyper/index.html).

--- a/docs/noodlebar/quick-start.md
+++ b/docs/noodlebar/quick-start.md
@@ -5,4 +5,10 @@ parent: "Noodlebar"
 layout: default
 ---
 
-## Work in progress
+Get up and running with NoodleBar in five simple steps:
+
+1. **Set up the base components** – Install the Authorization Registry, Organization Registry and Token Server using the provided Helm charts.
+2. **Configure service metadata** – Publish your API descriptions and access policies in the service catalog.
+3. **Create access rules** – Use Keyper or another approval tool to register policies for your consumers.
+4. **Enforce at your API gateway** – Integrate the NoodleBar enforcement endpoints with your gateway or service layer.
+5. **Consult the API reference** – Review the [NoodleBar API documentation](https://noodlebar.poort8.nl/scalar/) for details on each endpoint.


### PR DESCRIPTION
## Summary
- close directory listing codeblock in README
- fix minor typos and missing links
- update API links in guide
- correct DVU variable placeholder
- align HeyWim front matter and fill in quick starts and FAQ
- add NoodleBar quick start and FAQ content

## Testing
- `bundle exec jekyll build --source docs`
- `bundle exec htmlproofer ./_site --disable-external`