### PR TITLE
Fix sidebar layout to use wider screen

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -2,8 +2,10 @@
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
 
-$content-width: 1040px;
+// Define breakpoints for responsive design
+$breakpoint-lg: 1040px; // Large breakpoint for content width, chosen based on design requirements
 
+$content-width: $breakpoint-lg;
 @import "minima";
 
 // Basic styling

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -2,7 +2,7 @@
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
 
-$content-width: 1000px;
+$content-width: 1040px;
 
 @import "minima";
 
@@ -18,7 +18,7 @@ body {
 // Custom styles for navigation
 .page-container {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   margin-top: 30px;
 }
 

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -20,10 +20,14 @@ body {
 // Custom styles for navigation
 .page-container {
   display: flex;
-  flex-wrap: nowrap;
   margin-top: 30px;
 }
 
+@media (min-width: 768px) {
+  .page-container {
+    flex-wrap: nowrap;
+  }
+}
 .sidebar {
   flex: 0 0 250px;
   padding-right: 30px;


### PR DESCRIPTION
## Summary
- prevent sidebar wrapping by changing page container flex-wrap
- widen content width to 1040px

## Testing
- `bundle exec jekyll build --source docs`
- `bundle exec htmlproofer ./_site --disable-external`
- `bundle exec rspec`