### PR TITLE
Remove baseurl override in Jekyll workflow

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --source docs --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build --source docs
         env:
           JEKYLL_ENV: production
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- use `_config.yml` baseurl instead of passing it via CLI

## Testing
- `poetry run pre-commit run --files .github/workflows/jekyll.yml` *(fails: pyproject.toml not found)*
- `poetry run pytest --cov=orchestrator tests/` *(fails: pyproject.toml not found)*