### PR TITLE
Fix width for page wrapper

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -8,6 +8,11 @@ $breakpoint-lg: 1040px; // Large breakpoint for content width, chosen based on d
 $content-width: $breakpoint-lg;
 @import "minima";
 
+.page-content > .wrapper {
+  max-width: none;
+  width: 100%;
+}
+
 // Basic styling
 html,
 body {


### PR DESCRIPTION
## Summary
- ensure sidebar and page layout align by removing width constraint

## Testing
- `bundle exec jekyll build --source docs`
- `bundle exec htmlproofer ./_site --disable-external`
