### PR TITLE
Fix sidebar layout on small screens

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -108,6 +108,7 @@ body {
   }
 
   .sidebar {
+    position: static;
     flex: 0 0 100%;
     padding-right: 0;
     margin-right: 0;


### PR DESCRIPTION
## Summary
- tweak sidebar CSS so it no longer overlaps content on mobile widths

## Testing
- `bundle exec jekyll build --source docs`
- `bundle exec htmlproofer ./_site --disable-external`
