### PR TITLE
SUPER-70: Docsify Foundation Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
-# Poort8.Docs
+# Poort8 Documentation
 
-This repository contains the documentation portal for all Poort8 products, built with Jekyll and hosted on GitHub Pages.
+Welcome to the Poort8 documentation portal. This site hosts documentation for all Poort8 dataspaces.
+
+## Getting Started
+
+This documentation site is built with Docsify and provides information about:
+
+- **HeyWim** - [Coming in next steps]
+- **DVU** - [Coming in next steps] 
+- **GIR** - [Coming in next steps]
+- **CDA** - [Coming in next steps]
+
+## About This Site
+
+This is the new Docsify-based documentation site that replaces the previous Jekyll-based system. It provides:
+
+- Zero-build hosting via GitHub Pages
+- Runtime rendering for fast updates
+- Full-text search across all content
+- Dataspace-oriented navigation
+
+More content and navigation will be added in subsequent implementation steps.
 
 ## Project Structure
 

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,8 @@
+/* Poort8 Documentation - Custom CSS */
+/* This file will be populated with Poort8 branding in SUPER-71 */
+
+/* Basic structure ready for customization */
+.app-name {
+  /* Placeholder - will be styled in next step */
+  font-family: inherit;
+}

--- a/assets/images/poort8-logo.svg
+++ b/assets/images/poort8-logo.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="120" height="40" viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg">
+  <!-- Placeholder Poort8 Logo - to be replaced with actual logo -->
+  <rect x="0" y="0" width="120" height="40" fill="#0066cc" rx="4"/>
+  <text x="60" y="25" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">Poort8</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Poort8 Documentation</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+  <link rel="stylesheet" href="assets/css/custom.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'Poort8 Documentation',
+      repo: 'https://github.com/Poort8/Poort8.Docs',
+      loadSidebar: true,
+      subMaxLevel: 3,
+      search: 'auto',
+      logo: 'assets/images/poort8-logo.svg'
+    }
+  </script>
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
- Create index.html with Docsify 4.x configuration
- Add asset directories (/assets/css/, /assets/images/)
- Create placeholder custom.css and logo SVG
- Add .nojekyll for GitHub Pages direct serving
- Update README.md with Docsify introduction
- Configure zero-build hosting architecture

Implements spec.md section 3.1 exactly as specified. Ready for SUPER-71 (Global Navigation & Branding).