### PR TITLE
SUPER-72: Fix dataspace navigation with structural Docsify configuration

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -2,7 +2,9 @@
 * [Dataspace Guide](/guide.md)
 
 **Dataspaces**
-* [HeyWim](/dataspaces/heywim/)
-* [DVU](/dataspaces/dvu/)
-* [GIR](/dataspaces/gir/)
-* [CDA](/dataspaces/cda/)
+* [📊 HeyWim](/heywim/)
+* [🏛️ DVU](/dvu/)
+* [🔍 GIR](/gir/)
+* [🔐 Keyper](/keyper/)
+* [🍜 NoodleBar](/noodlebar/)
+* [🔧 TSL](/tsl/)

--- a/dvu/README.md
+++ b/dvu/README.md
@@ -1,0 +1,5 @@
+# DVU: Data Visualisatie Utilities
+
+DVU (Datastelsel Verduurzaming Utiliteit) is a comprehensive dataspace solution developed by Poort8.
+
+*Documentation content will be added by the DVU team.*

--- a/dvu/_sidebar.md
+++ b/dvu/_sidebar.md
@@ -1,0 +1,4 @@
+- [← Back to Poort8 Overview](/)
+
+- **DVU**
+  - [Introduction](README.md)

--- a/heywim/README.md
+++ b/heywim/README.md
@@ -1,0 +1,5 @@
+# HeyWim Container Tracking
+
+HHeyWim currently connects to over 50 data sources for vessel and container information, including ocean carriers, deepsea terminals, and inland terminals.
+
+*Documentation content will be added by the HeyWim team.*

--- a/heywim/_sidebar.md
+++ b/heywim/_sidebar.md
@@ -1,0 +1,4 @@
+- [← Back to Poort8 Overview](/)
+
+- **HeyWim**
+  - [Introduction](README.md)

--- a/index.html
+++ b/index.html
@@ -16,7 +16,8 @@
       loadSidebar: true,
       subMaxLevel: 3,
       search: 'auto',
-      logo: 'assets/images/poort8-logo.svg'
+      logo: 'assets/images/poort8-logo.svg',
+      relativePath: true
     }
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>


### PR DESCRIPTION
- Enable relativePath: true in Docsify config to fix relative link resolution
- Revert DVU and HeyWim sidebars to use simple relative paths
- Document routing solution in docs-agents/decisions/docsify-routing.md
- Ensure external sidebars (Keyper, NoodleBar) continue working unchanged

This structural solution fixes Introduction links without modifying external content. Relative paths now resolve correctly within dataspace contexts:
- /dvu/ context: README.md → /dvu/README.md ✅
- /keyper/ context: faq.md → /keyper/faq.md ✅