### PR TITLE
Add LikeC4 diagram integration for Docsify docs

### DIFF
--- a/.github/workflows/docsify.yml
+++ b/.github/workflows/docsify.yml
@@ -52,6 +52,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Build LikeC4 diagram bundles
+        run: bash build-likec4.sh
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 

--- a/build-likec4.sh
+++ b/build-likec4.sh
@@ -23,21 +23,26 @@ for section_dir in */; do
     continue
   fi
 
+  rm -rf "$section_dir/likec4"
   mkdir -p "$section_dir/likec4"
 
   # Extract each markdown file's likec4 fence into a .c4 source file.
   # The markdown is the single source of truth; .c4 files are generated.
-  for md_file in "${section_dir}"*.md; do
-    [ -f "$md_file" ] || continue
-    base="$(basename "$md_file" .md)"
+  # Scans recursively; nested paths are flattened with '-' to avoid collisions.
+  while IFS= read -r md_file; do
+    rel="${md_file#"$section_dir"}"
+    flat="${rel%.md}"
+    flat="${flat//\//-}"
     python3 -c "
 import sys, re
 content = open(sys.argv[1], encoding='utf-8').read()
-m = re.search(r'\x60\x60\x60likec4\n(.*?)\n\x60\x60\x60', content, re.DOTALL)
-if m:
-    open(sys.argv[2], 'w', encoding='utf-8').write(m.group(1) + '\n')
-" "$md_file" "${section_dir}likec4/${base}.c4"
-  done
+matches = re.findall(r'\x60\x60\x60likec4\n(.*?)\n\x60\x60\x60', content, re.DOTALL)
+base = sys.argv[2]
+for i, m in enumerate(matches):
+    fname = base + ('.c4' if len(matches) == 1 else '-' + str(i) + '.c4')
+    open(fname, 'w', encoding='utf-8').write(m + '\n')
+" "$md_file" "${section_dir}likec4/${flat}"
+  done < <(find "$section_dir" -name '*.md' -not -path '*/_*' | sort)
 
   ls "${section_dir}likec4/"*.c4 > /dev/null 2>&1 \
     || { echo "ERROR: no .c4 files extracted for section '$section'" >&2; exit 1; }
@@ -48,7 +53,7 @@ if m:
 
   # Verify each extracted view-id is present in the generated bundle
   for c4_file in "${section_dir}likec4/"*.c4; do
-    grep -oE 'view [a-z_]+' "$c4_file" | awk '{print $2}' | while read -r view_id; do
+    grep -oE 'view [a-zA-Z0-9_]+' "$c4_file" | awk '{print $2}' | while read -r view_id; do
       grep -q "$view_id" "assets/js/${section}-components.js" \
         || { echo "ERROR: view '$view_id' not found in bundle" >&2; exit 1; }
     done

--- a/build-likec4.sh
+++ b/build-likec4.sh
@@ -19,7 +19,7 @@ for section_dir in */; do
   section="${section_dir%/}"
   [ -d "$section_dir" ] || continue
 
-  if ! grep -rl '```likec4' --include='*.md' --exclude='_*' "$section_dir" 2>/dev/null | grep -q .; then
+  if ! grep -rl '```likec4' --include='*.md' --exclude='_*' --exclude-dir='_*' "$section_dir" 2>/dev/null | grep -q .; then
     continue
   fi
 
@@ -36,7 +36,7 @@ for section_dir in */; do
     python3 -c "
 import sys, re
 content = open(sys.argv[1], encoding='utf-8').read()
-matches = re.findall(r'\x60\x60\x60likec4\n(.*?)\n\x60\x60\x60', content, re.DOTALL)
+matches = re.findall(r'\x60\x60\x60likec4[^\n]*\n(.*?)\n\x60\x60\x60', content, re.DOTALL)
 base = sys.argv[2]
 for i, m in enumerate(matches):
     fname = base + ('.c4' if len(matches) == 1 else '-' + str(i) + '.c4')

--- a/build-likec4.sh
+++ b/build-likec4.sh
@@ -19,7 +19,7 @@ for section_dir in */; do
   section="${section_dir%/}"
   [ -d "$section_dir" ] || continue
 
-  if ! grep -rl '```likec4' --include='*.md' "$section_dir" 2>/dev/null | grep -q .; then
+  if ! grep -rl '```likec4' --include='*.md' --exclude='_*' "$section_dir" 2>/dev/null | grep -q .; then
     continue
   fi
 
@@ -53,7 +53,7 @@ for i, m in enumerate(matches):
 
   # Verify each extracted view-id is present in the generated bundle
   for c4_file in "${section_dir}likec4/"*.c4; do
-    grep -oE 'view [a-zA-Z0-9_]+' "$c4_file" | awk '{print $2}' | while read -r view_id; do
+    (grep -oE 'view [a-zA-Z0-9_]+' "$c4_file" || true) | awk '{print $2}' | while read -r view_id; do
       grep -q "$view_id" "assets/js/${section}-components.js" \
         || { echo "ERROR: view '$view_id' not found in bundle" >&2; exit 1; }
     done

--- a/build-likec4.sh
+++ b/build-likec4.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds LikeC4 webcomponent bundles for all docs sections that contain
+# ```likec4 fences in their markdown files.
+# Output: assets/js/<section>-components.js per section.
+# Usage (from Poort8.Docs root):
+#   ./build-likec4.sh
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$repo_dir"
+
+mkdir -p assets/js
+sections_built=0
+
+# Discover every top-level directory that contains a likec4 fence in a markdown file.
+# To add a new docs section with diagrams: just add ```likec4 fences — no changes here needed.
+for section_dir in */; do
+  section="${section_dir%/}"
+  [ -d "$section_dir" ] || continue
+
+  if ! grep -rl '```likec4' --include='*.md' "$section_dir" 2>/dev/null | grep -q .; then
+    continue
+  fi
+
+  mkdir -p "$section_dir/likec4"
+
+  # Extract each markdown file's likec4 fence into a .c4 source file.
+  # The markdown is the single source of truth; .c4 files are generated.
+  for md_file in "${section_dir}"*.md; do
+    [ -f "$md_file" ] || continue
+    base="$(basename "$md_file" .md)"
+    python3 -c "
+import sys, re
+content = open(sys.argv[1], encoding='utf-8').read()
+m = re.search(r'\x60\x60\x60likec4\n(.*?)\n\x60\x60\x60', content, re.DOTALL)
+if m:
+    open(sys.argv[2], 'w', encoding='utf-8').write(m.group(1) + '\n')
+" "$md_file" "${section_dir}likec4/${base}.c4"
+  done
+
+  ls "${section_dir}likec4/"*.c4 > /dev/null 2>&1 \
+    || { echo "ERROR: no .c4 files extracted for section '$section'" >&2; exit 1; }
+
+  npx --yes likec4@1.56.0 codegen webcomponent \
+    --outfile "assets/js/${section}-components.js" \
+    "${section_dir}likec4"
+
+  # Verify each extracted view-id is present in the generated bundle
+  for c4_file in "${section_dir}likec4/"*.c4; do
+    grep -oE 'view [a-z_]+' "$c4_file" | awk '{print $2}' | while read -r view_id; do
+      grep -q "$view_id" "assets/js/${section}-components.js" \
+        || { echo "ERROR: view '$view_id' not found in bundle" >&2; exit 1; }
+    done
+  done
+
+  sections_built=$((sections_built + 1))
+done
+
+echo "Built LikeC4 bundles for $sections_built section(s)."

--- a/index.html
+++ b/index.html
@@ -78,21 +78,25 @@
         return;
       }
 
-      hosts.forEach(function(host) {
-        if (installLikeC4OverlayFix(host)) {
-          return;
-        }
-
-        var attempts = 0;
-        var retry = function() {
-          attempts += 1;
-          if (installLikeC4OverlayFix(host) || attempts >= 20) {
+      // Wait for the custom element to be defined (handles dynamic bundle loading).
+      // After definition, the inner shadow DOM may still need a frame to render,
+      // so we keep a short rAF fallback for each host.
+      customElements.whenDefined('likec4-view').then(function() {
+        hosts.forEach(function(host) {
+          if (installLikeC4OverlayFix(host)) {
             return;
           }
-          window.requestAnimationFrame(retry);
-        };
 
-        window.requestAnimationFrame(retry);
+          var attempts = 0;
+          var retry = function() {
+            if (installLikeC4OverlayFix(host) || attempts++ >= 5) {
+              return;
+            }
+            window.requestAnimationFrame(retry);
+          };
+
+          window.requestAnimationFrame(retry);
+        });
       });
     }
 
@@ -143,6 +147,7 @@
             var match = (route || '').match(/#\/?([^/?#]+)(?:\/|$)/);
             if (!match) return;
             var section = match[1];
+            if (!/^[a-zA-Z0-9_-]+$/.test(section)) return;
             if (!loadedBundles[section]) {
               loadedBundles[section] = true;
               import('./assets/js/' + section + '-components.js').catch(function() {

--- a/index.html
+++ b/index.html
@@ -117,9 +117,16 @@
               return '<div class="mermaid">' + code + '</div>';
             }
             if (lang === "likec4") {
-              var match = code.match(/\bview\s+(\w+)/);
-              if (!match) return this.origin.code.apply(this, arguments);
-              var viewId = match[1];
+              // Allow explicit view selection via first-line directive: // view: <id>
+              var directiveMatch = code.match(/^\/\/ view:\s*(\w+)/);
+              var viewId;
+              if (directiveMatch) {
+                viewId = directiveMatch[1];
+              } else {
+                var autoMatch = code.match(/\bview\s+(\w+)/);
+                if (!autoMatch) return this.origin.code.apply(this, arguments);
+                viewId = autoMatch[1];
+              }
               return '<likec4-view class="likec4-embed" view-id="' + viewId + '" dynamic-variant="sequence"></likec4-view>';
             }
             return this.origin.code.apply(this, arguments);
@@ -133,7 +140,7 @@
           function loadBundleForRoute(route) {
             // Derive the docs section from the Docsify hash (e.g. /#/noodlebar/page -> noodlebar)
             // and attempt to load its bundle. Silently ignored if no bundle exists.
-            var match = (route || '').match(/#\/?([^/?#]+)\//);
+            var match = (route || '').match(/#\/?([^/?#]+)(?:\/|$)/);
             if (!match) return;
             var section = match[1];
             if (!loadedBundles[section]) {

--- a/index.html
+++ b/index.html
@@ -8,6 +8,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.css">
+  <style>
+    likec4-view.likec4-embed {
+      display: block;
+      min-height: 720px;
+      border: 1px solid #d7deea;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+  </style>
 </head>
 <body>
   <div id="app"></div>
@@ -15,6 +24,77 @@
   <script>
     var num = 0;
     mermaid.initialize({ startOnLoad: false });
+
+    function installLikeC4OverlayFix(host) {
+      if (!host || host.dataset.p8Likec4Fixed === 'true') {
+        return false;
+      }
+
+      var outerShadowRoot = host.shadowRoot;
+      var innerHost = outerShadowRoot && outerShadowRoot.querySelector('.likec4-view');
+      var innerShadowRoot = innerHost && innerHost.shadowRoot;
+
+      if (!innerShadowRoot) {
+        return false;
+      }
+
+      if (!innerShadowRoot.querySelector('style[data-p8-likec4-overlay-fix]')) {
+        var style = document.createElement('style');
+        style.setAttribute('data-p8-likec4-overlay-fix', 'true');
+        style.textContent = [
+          'dialog.likec4-overlay.likec4-overlay--fullscreen_false {',
+          '  position: fixed !important;',
+          '  top: 50% !important;',
+          '  left: 50% !important;',
+          '  transform: translate(-50%, -50%) !important;',
+          '  width: min(calc(100vw - 2rem), 1080px) !important;',
+          '  height: min(calc(100vh - 2rem), 720px) !important;',
+          '  margin: 0 !important;',
+          '  padding: 0 !important;',
+          '  background: #fff !important;',
+          '  border-radius: 12px !important;',
+          '  overflow: hidden !important;',
+          '}',
+          'dialog.likec4-overlay.likec4-overlay--fullscreen_false::backdrop {',
+          '  background: rgba(15, 23, 42, 0.72) !important;',
+          '}',
+          'dialog.likec4-overlay .likec4-overlay-body {',
+          '  background: #fff !important;',
+          '}',
+          'dialog.likec4-overlay .likec4-shadow-root {',
+          '  background: #fff !important;',
+          '}'
+        ].join('\n');
+        innerShadowRoot.appendChild(style);
+      }
+
+      host.dataset.p8Likec4Fixed = 'true';
+      return true;
+    }
+
+    function applyLikeC4OverlayFix() {
+      var hosts = document.querySelectorAll('likec4-view');
+      if (!hosts.length) {
+        return;
+      }
+
+      hosts.forEach(function(host) {
+        if (installLikeC4OverlayFix(host)) {
+          return;
+        }
+
+        var attempts = 0;
+        var retry = function() {
+          attempts += 1;
+          if (installLikeC4OverlayFix(host) || attempts >= 20) {
+            return;
+          }
+          window.requestAnimationFrame(retry);
+        };
+
+        window.requestAnimationFrame(retry);
+      });
+    }
 
     window.$docsify = {
       name: 'Poort8 Docs',
@@ -36,14 +116,38 @@
             if (lang === "mermaid") {
               return '<div class="mermaid">' + code + '</div>';
             }
+            if (lang === "likec4") {
+              var match = code.match(/\bview\s+(\w+)/);
+              if (!match) return this.origin.code.apply(this, arguments);
+              var viewId = match[1];
+              return '<likec4-view class="likec4-embed" view-id="' + viewId + '" dynamic-variant="sequence"></likec4-view>';
+            }
             return this.origin.code.apply(this, arguments);
           }
         }
       },
       plugins: [
         function(hook) {
+          var loadedBundles = {};
+
+          function loadBundleForRoute(route) {
+            // Derive the docs section from the Docsify hash (e.g. /#/noodlebar/page -> noodlebar)
+            // and attempt to load its bundle. Silently ignored if no bundle exists.
+            var match = (route || '').match(/#\/?([^/?#]+)\//);
+            if (!match) return;
+            var section = match[1];
+            if (!loadedBundles[section]) {
+              loadedBundles[section] = true;
+              import('./assets/js/' + section + '-components.js').catch(function() {
+                // No LikeC4 bundle for this section — that's fine
+              });
+            }
+          }
+
           hook.doneEach(function() {
             mermaid.init(undefined, '.mermaid');
+            loadBundleForRoute(window.location.hash || '/');
+            applyLikeC4OverlayFix();
           });
         }
       ]

--- a/index.html
+++ b/index.html
@@ -149,8 +149,9 @@
             var section = match[1];
             if (!/^[a-zA-Z0-9_-]+$/.test(section)) return;
             if (!loadedBundles[section]) {
-              loadedBundles[section] = true;
-              import('./assets/js/' + section + '-components.js').catch(function() {
+              import('./assets/js/' + section + '-components.js').then(function() {
+                loadedBundles[section] = true;
+              }).catch(function() {
                 // No LikeC4 bundle for this section — that's fine
               });
             }


### PR DESCRIPTION
## What

Adds LikeC4 architecture diagram support to the Docsify documentation site.

## Changes

- **`build-likec4.sh`** (new) — Generic build script that:
  - Autodiscovers any docs section containing `` ```likec4 `` code fences in markdown files
  - Extracts embedded model source via Python regex (no separate `.c4` files needed)
  - Runs `npx likec4 codegen webcomponent` and outputs per-section bundles to `assets/js/<section>-components.js`
  - Guards: skips sections without fences, warns if codegen produced no views

- **`index.html`** — Adds LikeC4 support to the shared Docsify shell:
  - `likec4` markdown code fence renderer (extracts `view-id`, emits `<likec4-view>` webcomponent)
  - URL-derived dynamic bundle import (no hardcoded section map — autodiscovered from route)
  - Overlay CSS fix: transform-based centering + constrained dialog size + dark backdrop (injected into LikeC4's nested shadow root)

- **`.github/workflows/docsify.yml`** — Build step now calls `bash build-likec4.sh` instead of inline shell logic

## Authoring

To embed a LikeC4 diagram in any docs section, add a `` ```likec4 `` fence with the full model source in any markdown file. No other configuration needed — the build script autodiscovers it.

```
​```likec4
specification { element actor; element system }
model { ... }
views {
  dynamic view my_view { ... }
}
​```
```