### PR TITLE
Fix Docsify Pages deployment workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Test 1: Link Checking (ignores internal Docsify routes)
       - name: Check Markdown Links 🔗

--- a/.github/workflows/docsify.yml
+++ b/.github/workflows/docsify.yml
@@ -15,10 +15,10 @@ permissions:
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
+# Queue Pages deployments so an in-flight deployment can finish cleanly.
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # Check if this should run
@@ -28,7 +28,7 @@ jobs:
       should-deploy: ${{ steps.check.outputs.should-deploy }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Check for Docsify
         id: check
         run: |
@@ -44,16 +44,16 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: check-docsify
     if: needs.check-docsify.outputs.should-deploy == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -61,7 +61,7 @@ jobs:
         run: bash build-likec4.sh
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Verify Docsify files
         run: |
@@ -89,11 +89,21 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload entire repository root (zero-build approach)
           path: '.'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+        continue-on-error: true
+
+      - name: Wait before retrying Pages deployment
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 30
+
+      - name: Retry GitHub Pages deployment
+        id: deployment_retry
+        if: steps.deployment.outcome == 'failure'
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- update GitHub Actions dependencies to the current major versions
- queue Pages deployments instead of canceling in-flight deployments
- retry `actions/deploy-pages` once after the transient `Deployment failed, try again later.` failure
- add Dependabot updates for GitHub Actions

## Analysis
The failed `Deploy Docsify to Pages` runs uploaded the Pages artifact successfully, then failed inside `actions/deploy-pages` after GitHub accepted the deployment payload. Manual retries on the same commits usually succeeded, which points to a transient/in-flight Pages deployment issue rather than a broken Docsify artifact. The workflow now avoids canceling active Pages deployments and retries the deploy action once.

## Validation
- confirmed latest action major tags exist
- ran `git diff --check`
- ran `build-likec4.sh` in the temp clone after forcing LF line endings for Bash on Windows